### PR TITLE
Add scipy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy
+scipy==1.1.0
 keras
 matplotlib
 mpld3


### PR DESCRIPTION
"imread" is depreciated after version 1.2.0 of Scipy. The code doesn't function if you keep the last version. You should have version 1.1.0 of scipy.